### PR TITLE
Fix pytorch compatibility issues

### DIFF
--- a/lib/likelihood_eval.py
+++ b/lib/likelihood_eval.py
@@ -58,7 +58,7 @@ def compute_binary_CE_loss(label_predictions, mortality_label):
 	n_traj_samples = label_predictions.size(0)
 	label_predictions = label_predictions.reshape(n_traj_samples, -1)
 	
-	idx_not_nan = 1 - torch.isnan(mortality_label)
+	idx_not_nan = ~torch.isnan(mortality_label)
 	if len(idx_not_nan) == 0.:
 		print("All are labels are NaNs!")
 		ce_loss = torch.Tensor(0.).to(get_device(mortality_label))
@@ -118,8 +118,8 @@ def compute_multiclass_CE_loss(label_predictions, true_label, mask):
 
 	res = []
 	for i in range(true_label.size(0)):
-		pred_masked = torch.masked_select(label_predictions[i], pred_mask[i].byte())
-		labels = torch.masked_select(true_label[i], label_mask[i].byte())
+		pred_masked = torch.masked_select(label_predictions[i], pred_mask[i].bool())
+		labels = torch.masked_select(true_label[i], label_mask[i].bool())
 	
 		pred_masked = pred_masked.reshape(-1, n_dims)
 
@@ -146,11 +146,11 @@ def compute_masked_likelihood(mu, data, mask, likelihood_func):
 	for i in range(n_traj_samples):
 		for k in range(n_traj):
 			for j in range(n_dims):
-				data_masked = torch.masked_select(data[i,k,:,j], mask[i,k,:,j].byte())
+				data_masked = torch.masked_select(data[i,k,:,j], mask[i,k,:,j].bool())
 				
 				#assert(torch.sum(data_masked == 0.) < 10)
 
-				mu_masked = torch.masked_select(mu[i,k,:,j], mask[i,k,:,j].byte())
+				mu_masked = torch.masked_select(mu[i,k,:,j], mask[i,k,:,j].bool())
 				log_prob = likelihood_func(mu_masked, data_masked, indices = (i,k,j))
 				res.append(log_prob)
 	# shape: [n_traj*n_traj_samples, 1]

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -573,7 +573,7 @@ def compute_loss_all_batches(model,
 			all_test_labels = all_test_labels.repeat(n_traj_samples,1,1)
 
 
-			idx_not_nan = 1 - torch.isnan(all_test_labels)
+			idx_not_nan = ~torch.isnan(all_test_labels)
 			classif_predictions = classif_predictions[idx_not_nan]
 			all_test_labels = all_test_labels[idx_not_nan]
 


### PR DESCRIPTION
Resolves https://github.com/YuliaRubanova/latent_ode/issues/9, as well as a `UserWarning: masked_select received a mask with dtype torch.uint8, this behavior is now deprecated,please use a mask with dtype torch.bool instead` warning that generates significant log noise (~3 GB for 100 iterations) for newer Pytorch versions.